### PR TITLE
Add bump2version for package versioning

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,10 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+tag_name = v{new_version}
+message = Bump version: {current_version} → {new_version}
+
+[bumpversion:file:goalee/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,12 @@ dist: clean ## builds source and wheel package
 
 install: ## install the package in development mode
 	pip install -e ".[dev,test]"
+
+bump-patch: ## bump patch version (0.1.0 -> 0.1.1)
+	bump2version patch
+
+bump-minor: ## bump minor version (0.1.0 -> 0.2.0)
+	bump2version minor
+
+bump-major: ## bump major version (0.1.0 -> 1.0.0)
+	bump2version major

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "build",
+    "bump2version",
     "ruff",
     "twine",
     "wheel",


### PR DESCRIPTION
Configure bump2version with .bumpversion.cfg to manage version in goalee/__init__.py with auto-commit and git tag (vX.Y.Z). Add bump-patch, bump-minor, bump-major Makefile targets.

Ultraworked with [Morpheus]